### PR TITLE
DataArrayN.arange を実装

### DIFF
--- a/ZeroD/Chapter3/NeuralNetwork.lean
+++ b/ZeroD/Chapter3/NeuralNetwork.lean
@@ -27,7 +27,7 @@ infer_var は標準では norm_num によって簡約を試みるが、
 具体的な値になるまで簡約できるタクティクが必要だった
 -/
 simproc reduceArangeLength (List.arange_length _ _ _) := fun e => do
-  if e.hasExprMVar then return .done (.mk e none false)
+  if e.hasFVar then return .continue
 
   let reduced ← withTransparency .all $ reduce e
   let rflCst : Expr := .const ``Eq.refl [1]


### PR DESCRIPTION
FloatにもDecidableなEqやLEは存在するけど、これはあくまで実行のためだけで証明には使えないことをようやく理解しました

ℚからFloatへの変換がそれぞれの値を作るたびに発生しますが、そのおかげで計算誤差がなくなって`List.arange 3.0 4.4 0.1`の最後が `4.3` と一致するようになったのはちょっと嬉しいかも

ちなみに、`DataArray.push`は実装を見た感じかなり効率が悪いので、効率の面でもコードの簡潔さの面でも`DataArray.intro`を使うべきっぽいです